### PR TITLE
Don't replay the odometer

### DIFF
--- a/opencog/generate/Aggregate.cc
+++ b/opencog/generate/Aggregate.cc
@@ -211,12 +211,12 @@ void Aggregate::print_odometer()
 
 bool Aggregate::do_step(void)
 {
+	// Erase the last connection that was made.
+	pop_frame();
+
 	logger().fine("Step odometer wheel %lu of %lu at depth %lu",
 	               _odo._step, _odo._size, _odo_stack.size());
 	print_odometer();
-
-	// Erase the last connection that was made.
-	pop_frame();
 
 	// Draw a new piece via callback, and attach it.
 	bool did_step = false;

--- a/opencog/generate/Aggregate.cc
+++ b/opencog/generate/Aggregate.cc
@@ -168,6 +168,7 @@ bool Aggregate::init_odometer(void)
 	_odo._size = _odo._to_connectors.size();
 	if (0 == _odo._size) return false;
 	_odo._step = 0;
+	_odo._frame_depth = _frame_stack.size();
 
 	logger().fine("Initialized odometer of length %lu", _odo._size);
 	print_odometer();
@@ -481,4 +482,10 @@ void Aggregate::pop_odo(void)
 	_odo = _odo_stack.top(); _odo_stack.pop();
 
 	logger().fine("==== Pop: Odo stack depth now %lu", _odo_stack.size());
+
+	// Realign the frame stack to where we started.
+	while (_odo._frame_depth < _frame_stack.size()) pop_frame();
+
+	// One extra push to match the pop in the stepper.
+	push_frame();
 }

--- a/opencog/generate/Aggregate.cc
+++ b/opencog/generate/Aggregate.cc
@@ -168,7 +168,6 @@ bool Aggregate::init_odometer(void)
 	_odo._size = _odo._to_connectors.size();
 	if (0 == _odo._size) return false;
 	_odo._step = 0;
-	_odo._frame_depth = _frame_stack.size();
 
 	logger().fine("Initialized odometer of length %lu", _odo._size);
 	print_odometer();
@@ -474,6 +473,8 @@ void Aggregate::push_odo(void)
 	_odo_stack.push(_odo);
 
 	logger().fine("==== Push: Odo stack depth now %lu", _odo_stack.size());
+
+	_odo._frame_depth = _frame_stack.size();
 }
 
 void Aggregate::pop_odo(void)

--- a/opencog/generate/Aggregate.cc
+++ b/opencog/generate/Aggregate.cc
@@ -479,13 +479,15 @@ void Aggregate::push_odo(void)
 
 void Aggregate::pop_odo(void)
 {
+	size_t restore_depth = _odo._frame_depth;
+
 	_cb->pop_odometer(_odo);
 	_odo = _odo_stack.top(); _odo_stack.pop();
 
 	logger().fine("==== Pop: Odo stack depth now %lu", _odo_stack.size());
 
 	// Realign the frame stack to where we started.
-	while (_odo._frame_depth < _frame_stack.size()) pop_frame();
+	while (restore_depth < _frame_stack.size()) pop_frame();
 
 	// One extra push to match the pop in the stepper.
 	push_frame();

--- a/opencog/generate/Aggregate.cc
+++ b/opencog/generate/Aggregate.cc
@@ -488,7 +488,4 @@ void Aggregate::pop_odo(void)
 
 	// Realign the frame stack to where we started.
 	while (restore_depth < _frame_stack.size()) pop_frame();
-
-	// One extra push to match the pop in the stepper.
-	push_frame();
 }

--- a/opencog/generate/Aggregate.h
+++ b/opencog/generate/Aggregate.h
@@ -47,6 +47,7 @@ private:
 	Odometer _odo;
 
 	std::stack<Frame> _frame_stack;
+	std::stack<HandleSeq> _odo_sections;
 	void push_frame();
 	void pop_frame();
 
@@ -59,7 +60,6 @@ private:
 
 	bool init_odometer(void);
 	bool step_odometer(void);
-	void reset_odometer(void);
 	bool do_step(void);
 	void print_wheel(size_t);
 	void print_odometer(void);

--- a/opencog/generate/Aggregate.h
+++ b/opencog/generate/Aggregate.h
@@ -52,8 +52,8 @@ private:
 	void pop_frame();
 
 	std::stack<Odometer> _odo_stack;
-	void push_odo(bool);
-	void pop_odo(bool);
+	void push_odo();
+	void pop_odo();
 
 	/// Accumulated set of fully-grounded solutions.
 	std::set<HandleSet> _solutions;

--- a/opencog/generate/Frame.h
+++ b/opencog/generate/Frame.h
@@ -50,6 +50,9 @@ struct Odometer
 	/// The next wheel to be stepped. This is an index into the
 	/// above sequences.
 	size_t _step;
+
+	/// The correspoding frame-stack depth, when this odo was created.
+	size_t _frame_depth;
 };
 
 /// Current traversal state

--- a/opencog/generate/Frame.h
+++ b/opencog/generate/Frame.h
@@ -47,13 +47,12 @@ struct Odometer
 	/// from-connectors.
 	HandleSeq _sections;
 
-	/// Ordered list of current to-sections. This is the actual
-	/// odometer, it is the thing that is stepped.
-	HandleSeq _current;
-
 	/// The next wheel to be stepped. This is an index into the
 	/// above sequences.
 	size_t _step;
+
+	/// The wheel that was most recently stepped.
+	size_t _last_step;
 };
 
 /// Current traversal state

--- a/opencog/generate/Frame.h
+++ b/opencog/generate/Frame.h
@@ -66,6 +66,9 @@ struct Frame
 
 	/// Completed links.
 	HandleSet _linkage;
+
+	size_t _nodo;
+	size_t _wheel;
 };
 
 /** @}*/

--- a/opencog/generate/Frame.h
+++ b/opencog/generate/Frame.h
@@ -50,9 +50,6 @@ struct Odometer
 	/// The next wheel to be stepped. This is an index into the
 	/// above sequences.
 	size_t _step;
-
-	/// The wheel that was most recently stepped.
-	size_t _last_step;
 };
 
 /// Current traversal state


### PR DESCRIPTION
Eliminate the odometer-replay strategy; its problematic.
Go back to the original strategy of rolling only the last few wheels.